### PR TITLE
Use exported methods to use the Web API handlers

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,10 +1,16 @@
-import { Hono } from 'hono'
-import { handle } from 'hono/vercel'
+import { Hono } from "hono";
+import { handle } from "hono/vercel";
 
-const app = new Hono().basePath('/api')
+const app = new Hono().basePath("/api");
 
-app.get('/', (c) => {
-  return c.json({ message: "Congrats! You've deployed Hono to Vercel" })
-})
+app.get("/", (c) => {
+  return c.json({ message: "Congrats! You've deployed Hono to Vercel" });
+});
 
-export default handle(app)
+const handler = handle(app);
+
+export const GET = handler;
+export const POST = handler;
+export const PATCH = handler;
+export const PUT = handler;
+export const OPTIONS = handler;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "type": "module", 
-
+  "type": "module",
   "scripts": {
     "start": "vercel dev",
     "deploy": "vercel"


### PR DESCRIPTION
This PR replaces the `export default handler(app)` with `export const [METHOD] = handler(app)` so we'll opt into the web api signature which is compatible with Hono (I think!)
